### PR TITLE
Add accessible display text and passive capture tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ real-home-frame.png
 *.log
 /config/
 dist/
+/server
+/display-capture
 AGENTS.md

--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ curl http://localhost:8088/healthz
 curl http://localhost:8088/api/v1/version
 curl http://localhost:8088/api/v1/status
 curl http://localhost:8088/api/v1/runtime/snapshot
+curl http://localhost:8088/api/v1/display/text | jq
 curl -o screen.png http://localhost:8088/api/v1/display/render.png
 ```
+
+`GET /api/v1/display/text` provides the current eight-row LCD as fixed-width decoded text, including highlighted ranges and selected text for screen-reader clients. The bundled `display-capture` command can passively record unique display states using GET requests only. See [Display accessibility and passive capture](docs/DISPLAY_ACCESSIBILITY.md) for the response contract and capture workflow.
 
 The app also serves:
 
@@ -87,6 +90,7 @@ Start here:
 
 - [Raspberry Pi install guide](docs/INSTALL_PI.md)
 - [Architecture](docs/ARCHITECTURE.md)
+- [Display accessibility and passive capture](docs/DISPLAY_ACCESSIBILITY.md)
 - [Protocol notes](docs/PROTOCOL.md)
 - [Node-RED integration guide](docs/integrations/node-red.md)
 - [Screenshot/reference index](docs/reference/screens/README.md)

--- a/cmd/display-capture/main.go
+++ b/cmd/display-capture/main.go
@@ -1,0 +1,65 @@
+// display-capture passively records unique amplifier LCD states as NDJSON.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/FtlC-ian/expert-amp-server/internal/capture"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "display-capture:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	flags := flag.NewFlagSet("display-capture", flag.ContinueOnError)
+	baseURL := flags.String("base-url", "http://127.0.0.1:8088", "expert-amp-server base URL")
+	output := flags.String("output", "display-captures.ndjson", "append-only NDJSON output path")
+	interval := flags.Duration("interval", time.Second, "snapshot polling interval")
+	requestTimeout := flags.Duration("request-timeout", 5*time.Second, "timeout for each read-only GET")
+	maxUnique := flags.Int("max-unique", 0, "stop after writing this many new unique states (0 = unlimited)")
+	once := flags.Bool("once", false, "poll once and exit, whether or not the state was already captured")
+	label := flags.String("transition-label", "", "operator-supplied label for the transition preceding the next newly captured state")
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("unexpected positional arguments")
+	}
+	if *requestTimeout <= 0 {
+		return errors.New("request timeout must be positive")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	stats, err := capture.Run(ctx, capture.Options{
+		Client: capture.Client{
+			BaseURL:    *baseURL,
+			HTTPClient: &http.Client{Timeout: *requestTimeout},
+		},
+		OutputPath:      *output,
+		PollInterval:    *interval,
+		MaxUnique:       *maxUnique,
+		Once:            *once,
+		TransitionLabel: *label,
+		OnRecord: func(record capture.Record) {
+			fmt.Fprintf(os.Stderr, "captured sequence=%d hash=%s label=%q\n", record.Sequence, record.StateHash, record.TransitionLabel)
+		},
+	})
+	fmt.Fprintf(os.Stderr, "polls=%d written=%d duplicates=%d output=%s\n", stats.Polls, stats.Written, stats.Skipped, *output)
+	return err
+}

--- a/cmd/display-capture/main_test.go
+++ b/cmd/display-capture/main_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsNonPositiveRequestTimeout(t *testing.T) {
+	for _, value := range []string{"0", "-1s"} {
+		t.Run(value, func(t *testing.T) {
+			err := run([]string{"-request-timeout", value})
+			if err == nil || !strings.Contains(err.Error(), "request timeout must be positive") {
+				t.Fatalf("run error = %v, want positive-timeout validation", err)
+			}
+		})
+	}
+}

--- a/docs/DISPLAY_ACCESSIBILITY.md
+++ b/docs/DISPLAY_ACCESSIBILITY.md
@@ -1,0 +1,71 @@
+# Display accessibility and passive capture
+
+Expert Amp Server exposes the current LCD as text without requiring a screenshot or visual transcription. This is the foundation for screen-reader clients and for model-specific menu recognition.
+
+## Accessible text endpoint
+
+`GET /api/v1/display/text` returns the standard `{ "success": true, "data": ... }` envelope. Its data includes:
+
+- `rows`: exactly eight strings of exactly 40 characters, preserving the physical LCD geometry
+- `highlightedSpans`: contiguous reverse-video ranges with zero-based row and column coordinates
+- `selectedText`: non-blank highlighted text in row-major order
+- `sequence` and `updatedAt`: the authoritative runtime display identity and timestamp
+- `source` and `modelName`: capture context when available
+- `screenText`: the existing trimmed decoder output as a compatibility fallback
+
+Unknown or custom glyphs decode as spaces. Their byte values are not lost: clients that need glyph-level evidence can read the exact `chars` and `attrs` arrays from `GET /api/v1/display/state`.
+
+The endpoint describes the current display. It does not recognize a menu page, assign meaning to custom symbols, or send amplifier controls.
+
+## Passive display recorder
+
+`display-capture` polls only `GET /api/v1/version` and `GET /api/v1/runtime/snapshot`. It never calls an action or settings endpoint.
+
+Build it with:
+
+```bash
+go build -o display-capture ./cmd/display-capture
+```
+
+Record new display states until interrupted:
+
+```bash
+./display-capture \
+  -base-url http://amp.local:8088 \
+  -output 2k-fa-display-captures.ndjson
+```
+
+Record one bounded observation with an operator-supplied transition label:
+
+```bash
+./display-capture \
+  -base-url http://amp.local:8088 \
+  -output 2k-fa-display-captures.ndjson \
+  -once \
+  -transition-label "pressed SET"
+```
+
+Use `-max-unique N` to stop after recording `N` previously unseen states. `-interval` controls the polling interval and defaults to one second.
+
+The output is append-only NDJSON with one JSON object per first-seen exact state. Each record includes:
+
+- a deterministic SHA-256 `stateHash` and `previousStateHash`
+- the optional `transitionLabel`
+- the exact 8x40 `chars` and `attrs` arrays
+- decoded `screenText`, LCD flags, and complete frame metadata
+- runtime sequence, source, frame kind, and timestamps
+- server build metadata and amplifier telemetry/model context
+
+The hash covers characters, attributes, and LCD flags, but not timestamps or sequence numbers. The recorder scans an existing output file on startup, so it can resume without duplicating states already captured. Transition links are based only on states observed during the current run: if a previously captured screen is revisited, it becomes the transition source for the next new state, but the recorder never invents a transition from an old file's final line.
+
+Capture files are created with owner-only permissions. Keep the raw NDJSON as evidence: recognizers should be derived from it without rewriting the original observations.
+
+## Suggested 2K-FA capture session
+
+1. Record the home screen once.
+2. Start the passive recorder before entering Set mode.
+3. Navigate only through the known manual-derived menu path, without changing values.
+4. Stop after one observation of each menu item at its current value.
+5. Compare a small sample against the physical LCD to validate decoded text and highlight placement.
+
+Do not automate traversal from captures alone. A future model-specific recognizer must reject unknown screens, and any traversal state machine must abort on a sequence timeout or unexpected state.

--- a/internal/api/display_text.go
+++ b/internal/api/display_text.go
@@ -1,0 +1,26 @@
+package api
+
+import "time"
+
+// DisplayTextSpan identifies a contiguous highlighted range on one LCD row.
+// StartColumn is inclusive and EndColumn is exclusive.
+type DisplayTextSpan struct {
+	Row         int    `json:"row"`
+	StartColumn int    `json:"startColumn"`
+	EndColumn   int    `json:"endColumn"`
+	Text        string `json:"text"`
+}
+
+// DisplayText is the screen-reader-friendly view of the current LCD state.
+// Rows preserve the physical 8x40 geometry; ScreenText is the existing trimmed
+// frame decoder output retained as a fallback for clients.
+type DisplayText struct {
+	Rows             []string          `json:"rows"`
+	HighlightedSpans []DisplayTextSpan `json:"highlightedSpans"`
+	SelectedText     string            `json:"selectedText"`
+	Sequence         uint64            `json:"sequence"`
+	UpdatedAt        time.Time         `json:"updatedAt"`
+	Source           string            `json:"source,omitempty"`
+	ModelName        string            `json:"modelName,omitempty"`
+	ScreenText       string            `json:"screenText,omitempty"`
+}

--- a/internal/apidocs/openapi.json
+++ b/internal/apidocs/openapi.json
@@ -157,6 +157,23 @@
         }
       }
     },
+    "/api/v1/display/text": {
+      "get": {
+        "tags": [
+          "Display"
+        ],
+        "summary": "Get accessible display text",
+        "description": "Returns a screen-reader-friendly view of the current runtime LCD. rows always contains eight strings of exactly 40 characters, preserving physical geometry. highlightedSpans use zero-based rows and inclusive startColumn/exclusive endColumn coordinates. Custom glyphs are left blank rather than assigned guessed semantics; screenText retains the existing trimmed frame text as a fallback, and /api/v1/display/state remains the raw character/attribute source.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DisplayTextResponse"
+          },
+          "405": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/display/frame": {
       "get": {
         "tags": [
@@ -644,6 +661,16 @@
           }
         }
       },
+      "DisplayTextResponse": {
+        "description": "Accessible display text envelope",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ResponseDisplayText"
+            }
+          }
+        }
+      },
       "FrameInfoResponse": {
         "description": "Frame metadata envelope",
         "content": {
@@ -825,6 +852,22 @@
           },
           "data": {
             "$ref": "#/components/schemas/DisplayStateEnvelopeData"
+          }
+        }
+      },
+      "ResponseDisplayText": {
+        "type": "object",
+        "required": [
+          "success",
+          "data"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/DisplayText"
           }
         }
       },
@@ -1080,6 +1123,90 @@
                 "maximum": 255
               }
             }
+          }
+        }
+      },
+      "DisplayText": {
+        "type": "object",
+        "required": [
+          "rows",
+          "highlightedSpans",
+          "selectedText",
+          "sequence",
+          "updatedAt"
+        ],
+        "properties": {
+          "rows": {
+            "type": "array",
+            "description": "Decoded LCD rows with physical spacing preserved. Unknown/custom glyphs decode as spaces.",
+            "minItems": 8,
+            "maxItems": 8,
+            "items": {
+              "type": "string",
+              "minLength": 40,
+              "maxLength": 40
+            }
+          },
+          "highlightedSpans": {
+            "type": "array",
+            "description": "Contiguous reverse-video ranges in row-major order.",
+            "items": {
+              "$ref": "#/components/schemas/DisplayTextSpan"
+            }
+          },
+          "selectedText": {
+            "type": "string",
+            "description": "Non-blank highlighted span text, trimmed and joined with newlines in row-major order."
+          },
+          "sequence": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "source": {
+            "type": "string"
+          },
+          "modelName": {
+            "type": "string"
+          },
+          "screenText": {
+            "type": "string",
+            "description": "Existing trimmed frame decoder output retained as a fallback."
+          }
+        }
+      },
+      "DisplayTextSpan": {
+        "type": "object",
+        "required": [
+          "row",
+          "startColumn",
+          "endColumn",
+          "text"
+        ],
+        "properties": {
+          "row": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 7
+          },
+          "startColumn": {
+            "type": "integer",
+            "description": "Inclusive zero-based start column.",
+            "minimum": 0,
+            "maximum": 39
+          },
+          "endColumn": {
+            "type": "integer",
+            "description": "Exclusive zero-based end column.",
+            "minimum": 1,
+            "maximum": 40
+          },
+          "text": {
+            "type": "string",
+            "description": "Decoded text across the complete highlighted geometry."
           }
         }
       },

--- a/internal/capture/recorder.go
+++ b/internal/capture/recorder.go
@@ -1,0 +1,335 @@
+// Package capture records passive observations of the amplifier display.
+package capture
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/FtlC-ian/expert-amp-server/internal/api"
+	"github.com/FtlC-ian/expert-amp-server/internal/display"
+	ampRuntime "github.com/FtlC-ian/expert-amp-server/internal/runtime"
+)
+
+const captureFormat = "expert-amp-display-capture/v1"
+
+type VersionInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit,omitempty"`
+	BuildDate string `json:"buildDate,omitempty"`
+	Channel   string `json:"channel,omitempty"`
+}
+
+type ServerMetadata struct {
+	BaseURL string `json:"baseUrl"`
+	VersionInfo
+}
+
+type AmplifierMetadata struct {
+	ModelName string        `json:"modelName,omitempty"`
+	Telemetry api.Telemetry `json:"telemetry"`
+}
+
+// Record is one first-seen exact LCD state. Chars and Attrs retain the full
+// protocol geometry, including custom glyph bytes that have no decoded text.
+type Record struct {
+	Format            string                           `json:"format"`
+	StateHash         string                           `json:"stateHash"`
+	PreviousStateHash string                           `json:"previousStateHash,omitempty"`
+	TransitionLabel   string                           `json:"transitionLabel,omitempty"`
+	CapturedAt        time.Time                        `json:"capturedAt"`
+	SnapshotUpdatedAt time.Time                        `json:"snapshotUpdatedAt,omitempty"`
+	Sequence          uint64                           `json:"sequence"`
+	Source            string                           `json:"source,omitempty"`
+	FrameKind         string                           `json:"frameKind,omitempty"`
+	Chars             [display.Rows][display.Cols]byte `json:"chars"`
+	Attrs             [display.Rows][display.Cols]byte `json:"attrs"`
+	ScreenText        string                           `json:"screenText"`
+	LCDFlags          *api.LCDFlags                    `json:"lcdFlags,omitempty"`
+	Frame             api.FrameInfo                    `json:"frame"`
+	Server            ServerMetadata                   `json:"server"`
+	Amplifier         AmplifierMetadata                `json:"amplifier"`
+}
+
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func (c Client) Version(ctx context.Context) (VersionInfo, error) {
+	var version VersionInfo
+	if err := c.get(ctx, "/api/v1/version", &version); err != nil {
+		return VersionInfo{}, err
+	}
+	return version, nil
+}
+
+func (c Client) Snapshot(ctx context.Context) (ampRuntime.Snapshot, error) {
+	var snapshot ampRuntime.Snapshot
+	if err := c.get(ctx, "/api/v1/runtime/snapshot", &snapshot); err != nil {
+		return ampRuntime.Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func (c Client) get(ctx context.Context, path string, dst any) error {
+	baseURL, err := url.Parse(strings.TrimRight(c.BaseURL, "/"))
+	if err != nil {
+		return fmt.Errorf("parse base URL: %w", err)
+	}
+	if baseURL.Scheme != "http" && baseURL.Scheme != "https" {
+		return fmt.Errorf("base URL must use http or https")
+	}
+	requestURL := baseURL.JoinPath(strings.TrimLeft(path, "/"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("create GET %s: %w", path, err)
+	}
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("GET %s: server returned %s: %s", path, resp.Status, strings.TrimSpace(string(body)))
+	}
+	var envelope struct {
+		Success bool            `json:"success"`
+		Data    json.RawMessage `json:"data"`
+		Error   string          `json:"error"`
+		Message string          `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return fmt.Errorf("decode GET %s: %w", path, err)
+	}
+	if !envelope.Success {
+		message := envelope.Error
+		if message == "" {
+			message = envelope.Message
+		}
+		return fmt.Errorf("GET %s: API failure: %s", path, message)
+	}
+	if err := json.Unmarshal(envelope.Data, dst); err != nil {
+		return fmt.Errorf("decode GET %s data: %w", path, err)
+	}
+	return nil
+}
+
+type Options struct {
+	Client          Client
+	OutputPath      string
+	PollInterval    time.Duration
+	MaxUnique       int
+	Once            bool
+	TransitionLabel string
+	Now             func() time.Time
+	OnRecord        func(Record)
+}
+
+type Stats struct {
+	Polls   int
+	Written int
+	Skipped int
+}
+
+// Run polls read-only endpoints and appends first-seen states as NDJSON.
+func Run(ctx context.Context, opts Options) (Stats, error) {
+	if strings.TrimSpace(opts.OutputPath) == "" {
+		return Stats{}, errors.New("output path is required")
+	}
+	if opts.PollInterval <= 0 {
+		return Stats{}, errors.New("poll interval must be positive")
+	}
+	if opts.MaxUnique < 0 {
+		return Stats{}, errors.New("max unique must not be negative")
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+
+	version, err := opts.Client.Version(ctx)
+	if err != nil {
+		return Stats{}, fmt.Errorf("read server metadata: %w", err)
+	}
+	output, seen, err := openOutput(opts.OutputPath)
+	if err != nil {
+		return Stats{}, err
+	}
+	defer output.Close()
+	encoder := json.NewEncoder(output)
+	transitionLabel := strings.TrimSpace(opts.TransitionLabel)
+	var previousHash string
+
+	var stats Stats
+	for {
+		snapshot, err := opts.Client.Snapshot(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return stats, nil
+			}
+			return stats, err
+		}
+		stats.Polls++
+		hash := StateHash(snapshot.State, snapshot.Frame.LCDFlags)
+		if _, exists := seen[hash]; exists {
+			stats.Skipped++
+			// A previously captured state can still be the real source of the
+			// next transition after a recorder restart or menu revisit.
+			previousHash = hash
+		} else {
+			record := Record{
+				Format:            captureFormat,
+				StateHash:         hash,
+				PreviousStateHash: previousHash,
+				TransitionLabel:   transitionLabel,
+				CapturedAt:        opts.Now().UTC(),
+				SnapshotUpdatedAt: snapshot.UpdatedAt,
+				Sequence:          snapshot.Sequence,
+				Source:            snapshot.Source,
+				FrameKind:         snapshot.FrameKind,
+				Chars:             snapshot.State.Chars,
+				Attrs:             snapshot.State.Attrs,
+				ScreenText:        snapshot.Frame.ScreenText,
+				LCDFlags:          snapshot.Frame.LCDFlags,
+				Frame:             snapshot.Frame,
+				Server: ServerMetadata{
+					BaseURL:     strings.TrimRight(opts.Client.BaseURL, "/"),
+					VersionInfo: version,
+				},
+				Amplifier: AmplifierMetadata{
+					ModelName: snapshot.Telemetry.ModelName,
+					Telemetry: snapshot.Telemetry,
+				},
+			}
+			if err := encoder.Encode(record); err != nil {
+				return stats, fmt.Errorf("append capture: %w", err)
+			}
+			if err := output.Sync(); err != nil {
+				return stats, fmt.Errorf("sync capture: %w", err)
+			}
+			seen[hash] = struct{}{}
+			previousHash = hash
+			transitionLabel = ""
+			stats.Written++
+			if opts.OnRecord != nil {
+				opts.OnRecord(record)
+			}
+		}
+
+		if opts.Once || (opts.MaxUnique > 0 && stats.Written >= opts.MaxUnique) {
+			return stats, nil
+		}
+		timer := time.NewTimer(opts.PollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return stats, nil
+		case <-timer.C:
+		}
+	}
+}
+
+// StateHash returns a deterministic identity for the exact character,
+// attribute, and LCD flag state. Sequence and timestamps intentionally do not
+// participate, so repeated snapshots deduplicate across recorder restarts.
+func StateHash(state display.State, flags *api.LCDFlags) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(captureFormat))
+	for row := range state.Chars {
+		_, _ = h.Write(state.Chars[row][:])
+	}
+	for row := range state.Attrs {
+		_, _ = h.Write(state.Attrs[row][:])
+	}
+	if flags == nil {
+		_, _ = h.Write([]byte{0})
+	} else {
+		_, _ = h.Write([]byte{1})
+		var buf [4]byte
+		binary.LittleEndian.PutUint16(buf[0:2], flags.RawInverted)
+		binary.LittleEndian.PutUint16(buf[2:4], flags.Decoded)
+		_, _ = h.Write(buf[:])
+		_, _ = h.Write([]byte{boolByte(flags.ChecksumPresent), boolByte(flags.ChecksumValid)})
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+func boolByte(value bool) byte {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func openOutput(path string) (*os.File, map[string]struct{}, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open capture output: %w", err)
+	}
+	seen := make(map[string]struct{})
+	needsSeparator := false
+	if info, err := file.Stat(); err != nil {
+		file.Close()
+		return nil, nil, fmt.Errorf("stat capture output: %w", err)
+	} else if info.Size() > 0 {
+		var last [1]byte
+		if _, err := file.ReadAt(last[:], info.Size()-1); err != nil {
+			file.Close()
+			return nil, nil, fmt.Errorf("read capture output boundary: %w", err)
+		}
+		needsSeparator = last[0] != '\n'
+	}
+	scanner := bufio.NewScanner(file)
+	buffer := make([]byte, 64*1024)
+	scanner.Buffer(buffer, 4*1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		if len(strings.TrimSpace(scanner.Text())) == 0 {
+			continue
+		}
+		var existing struct {
+			StateHash string `json:"stateHash"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &existing); err != nil {
+			file.Close()
+			return nil, nil, fmt.Errorf("read existing capture line %d: %w", line, err)
+		}
+		if existing.StateHash == "" {
+			file.Close()
+			return nil, nil, fmt.Errorf("read existing capture line %d: missing stateHash", line)
+		}
+		seen[existing.StateHash] = struct{}{}
+	}
+	if err := scanner.Err(); err != nil {
+		file.Close()
+		return nil, nil, fmt.Errorf("read existing capture: %w", err)
+	}
+	if needsSeparator {
+		if _, err := file.WriteString("\n"); err != nil {
+			file.Close()
+			return nil, nil, fmt.Errorf("separate existing capture: %w", err)
+		}
+		if err := file.Sync(); err != nil {
+			file.Close()
+			return nil, nil, fmt.Errorf("sync capture separator: %w", err)
+		}
+	}
+	return file, seen, nil
+}

--- a/internal/capture/recorder_test.go
+++ b/internal/capture/recorder_test.go
@@ -1,0 +1,360 @@
+package capture
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/FtlC-ian/expert-amp-server/internal/api"
+	"github.com/FtlC-ian/expert-amp-server/internal/display"
+	ampRuntime "github.com/FtlC-ian/expert-amp-server/internal/runtime"
+)
+
+func TestClientPreservesBaseURLPathPrefix(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/expert-amp/api/v1/version" {
+			t.Errorf("request path = %q, want path prefix preserved", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.Response{Success: true, Data: VersionInfo{Version: "1.2.3"}})
+	}))
+	defer server.Close()
+
+	version, err := (Client{BaseURL: server.URL + "/expert-amp/", HTTPClient: server.Client()}).Version(context.Background())
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if version.Version != "1.2.3" {
+		t.Fatalf("version = %q, want 1.2.3", version.Version)
+	}
+}
+
+func TestClientPreservesEscapedBaseURLPathPrefix(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI != "/team%2Falpha/api/v1/version" {
+			t.Errorf("request URI = %q, want escaped path prefix preserved", r.RequestURI)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.Response{Success: true, Data: VersionInfo{Version: "1.2.3"}})
+	}))
+	defer server.Close()
+
+	if _, err := (Client{BaseURL: server.URL + "/team%2Falpha", HTTPClient: server.Client()}).Version(context.Background()); err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+}
+
+func TestRunRecordsUniqueStatesUsingGETOnly(t *testing.T) {
+	first := testSnapshot(4, "HOME", 0x07fe)
+	second := testSnapshot(5, "SET MENU", 0x27fe)
+	server := snapshotServer(t, []ampRuntime.Snapshot{first, first, second})
+	defer server.Close()
+
+	output := filepath.Join(t.TempDir(), "capture.ndjson")
+	stats, err := Run(context.Background(), Options{
+		Client:          Client{BaseURL: server.URL, HTTPClient: server.Client()},
+		OutputPath:      output,
+		PollInterval:    time.Millisecond,
+		MaxUnique:       2,
+		TransitionLabel: "press SET",
+		Now:             func() time.Time { return time.Date(2026, 7, 20, 14, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Polls != 3 || stats.Written != 2 || stats.Skipped != 1 {
+		t.Fatalf("stats = %+v, want 3 polls, 2 written, 1 skipped", stats)
+	}
+
+	records := readRecords(t, output)
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want 2", len(records))
+	}
+	if records[0].Format != captureFormat || records[0].Sequence != 4 {
+		t.Fatalf("unexpected first record: %+v", records[0])
+	}
+	if records[0].Chars != first.State.Chars || records[0].Attrs != first.State.Attrs {
+		t.Fatal("first record did not preserve exact chars and attrs")
+	}
+	if records[0].ScreenText != "HOME" || records[0].LCDFlags == nil || records[0].LCDFlags.Decoded != 0x07fe {
+		t.Fatalf("first frame metadata = %+v", records[0].Frame)
+	}
+	if records[0].Server.Version != "1.2.3" || records[0].Amplifier.ModelName != "Expert 2K-FA" {
+		t.Fatalf("capture metadata = server %+v amplifier %+v", records[0].Server, records[0].Amplifier)
+	}
+	if records[0].TransitionLabel != "press SET" {
+		t.Fatalf("transition label = %q", records[0].TransitionLabel)
+	}
+	if records[1].TransitionLabel != "" {
+		t.Fatalf("transition label leaked to later state: %q", records[1].TransitionLabel)
+	}
+	if records[1].PreviousStateHash != records[0].StateHash {
+		t.Fatalf("previous state hash = %q, want %q", records[1].PreviousStateHash, records[0].StateHash)
+	}
+}
+
+func TestRunResumesDedupFromExistingOutput(t *testing.T) {
+	first := testSnapshot(4, "HOME", 0x07fe)
+	second := testSnapshot(5, "SET MENU", 0x27fe)
+	output := filepath.Join(t.TempDir(), "capture.ndjson")
+	existing := Record{Format: captureFormat, StateHash: StateHash(first.State, first.Frame.LCDFlags), Sequence: first.Sequence}
+	file, err := os.Create(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewEncoder(file).Encode(existing); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	server := snapshotServer(t, []ampRuntime.Snapshot{first, second})
+	defer server.Close()
+	stats, err := Run(context.Background(), Options{
+		Client:       Client{BaseURL: server.URL, HTTPClient: server.Client()},
+		OutputPath:   output,
+		PollInterval: time.Millisecond,
+		MaxUnique:    1,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Polls != 2 || stats.Written != 1 || stats.Skipped != 1 {
+		t.Fatalf("stats = %+v, want resumed duplicate to be skipped", stats)
+	}
+	records := readRecords(t, output)
+	if len(records) != 2 || records[1].Sequence != second.Sequence {
+		t.Fatalf("records after resume = %+v", records)
+	}
+	if records[1].PreviousStateHash != existing.StateHash {
+		t.Fatalf("previous state hash = %q, want existing hash %q", records[1].PreviousStateHash, existing.StateHash)
+	}
+}
+
+func TestRunUsesLastObservedDuplicateAsTransitionSource(t *testing.T) {
+	first := testSnapshot(4, "HOME", 0x07fe)
+	second := testSnapshot(5, "SET MENU", 0x27fe)
+	output := filepath.Join(t.TempDir(), "capture.ndjson")
+	for _, snapshot := range []ampRuntime.Snapshot{first, second} {
+		existing := Record{
+			Format:    captureFormat,
+			StateHash: StateHash(snapshot.State, snapshot.Frame.LCDFlags),
+			Sequence:  snapshot.Sequence,
+		}
+		file, err := os.OpenFile(output, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.NewEncoder(file).Encode(existing); err != nil {
+			file.Close()
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	third := testSnapshot(6, "FAN MODE", 0x27fe)
+	server := snapshotServer(t, []ampRuntime.Snapshot{first, third})
+	defer server.Close()
+	stats, err := Run(context.Background(), Options{
+		Client:       Client{BaseURL: server.URL, HTTPClient: server.Client()},
+		OutputPath:   output,
+		PollInterval: time.Millisecond,
+		MaxUnique:    1,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Polls != 2 || stats.Written != 1 || stats.Skipped != 1 {
+		t.Fatalf("stats = %+v", stats)
+	}
+	records := readRecords(t, output)
+	if got, want := records[2].PreviousStateHash, StateHash(first.State, first.Frame.LCDFlags); got != want {
+		t.Fatalf("previous state hash = %q, want last observed duplicate %q", got, want)
+	}
+}
+
+func TestRunDoesNotInferTransitionFromPreviousSession(t *testing.T) {
+	old := testSnapshot(4, "OLD SESSION", 0x07fe)
+	current := testSnapshot(5, "CURRENT", 0x27fe)
+	output := filepath.Join(t.TempDir(), "capture.ndjson")
+	existing := Record{Format: captureFormat, StateHash: StateHash(old.State, old.Frame.LCDFlags), Sequence: old.Sequence}
+	file, err := os.Create(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewEncoder(file).Encode(existing); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	server := snapshotServer(t, []ampRuntime.Snapshot{current})
+	defer server.Close()
+	stats, err := Run(context.Background(), Options{
+		Client:       Client{BaseURL: server.URL, HTTPClient: server.Client()},
+		OutputPath:   output,
+		PollInterval: time.Millisecond,
+		Once:         true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Polls != 1 || stats.Written != 1 {
+		t.Fatalf("stats = %+v", stats)
+	}
+	records := readRecords(t, output)
+	if got := records[1].PreviousStateHash; got != "" {
+		t.Fatalf("previous state hash = %q, want empty without a current-session predecessor", got)
+	}
+}
+
+func TestRunSeparatesExistingFinalRecordWithoutNewline(t *testing.T) {
+	first := testSnapshot(4, "HOME", 0x07fe)
+	second := testSnapshot(5, "SET MENU", 0x27fe)
+	output := filepath.Join(t.TempDir(), "capture.ndjson")
+	existing := Record{Format: captureFormat, StateHash: StateHash(first.State, first.Frame.LCDFlags), Sequence: first.Sequence}
+	data, err := json.Marshal(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(output, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := snapshotServer(t, []ampRuntime.Snapshot{second})
+	defer server.Close()
+	stats, err := Run(context.Background(), Options{
+		Client:       Client{BaseURL: server.URL, HTTPClient: server.Client()},
+		OutputPath:   output,
+		PollInterval: time.Millisecond,
+		Once:         true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Polls != 1 || stats.Written != 1 {
+		t.Fatalf("stats = %+v", stats)
+	}
+	records := readRecords(t, output)
+	if len(records) != 2 || records[0].StateHash != existing.StateHash || records[1].Sequence != second.Sequence {
+		t.Fatalf("records = %+v", records)
+	}
+}
+
+func TestStateHashCoversExactDisplayAndFlagsButNotSnapshotMetadata(t *testing.T) {
+	state := display.NewState()
+	flags := &api.LCDFlags{RawInverted: 0xf801, Decoded: 0x07fe, ChecksumPresent: true, ChecksumValid: true}
+	want := StateHash(state, flags)
+	copyFlags := *flags
+	if got := StateHash(state, &copyFlags); got != want {
+		t.Fatalf("equal state hash = %q, want %q", got, want)
+	}
+	changedChar := state
+	changedChar.Chars[7][39]++
+	if got := StateHash(changedChar, flags); got == want {
+		t.Fatal("character change did not change hash")
+	}
+	changedAttr := state
+	changedAttr.Attrs[7][39]++
+	if got := StateHash(changedAttr, flags); got == want {
+		t.Fatal("attribute change did not change hash")
+	}
+	changedFlags := *flags
+	changedFlags.Decoded = 0x27fe
+	if got := StateHash(state, &changedFlags); got == want {
+		t.Fatal("LCD flag change did not change hash")
+	}
+}
+
+func testSnapshot(sequence uint64, text string, decoded uint16) ampRuntime.Snapshot {
+	state := display.NewState()
+	state.SetRow(0, text)
+	state.SetAttr(0, 0, 0x80)
+	flags := &api.LCDFlags{
+		RawInverted:     ^decoded,
+		Decoded:         decoded,
+		ChecksumPresent: true,
+		ChecksumValid:   true,
+		LEDs:            &api.LCDLEDs{Set: decoded&0x2000 != 0},
+	}
+	return ampRuntime.Snapshot{
+		State:     state,
+		Telemetry: api.Telemetry{ModelName: "Expert 2K-FA", Band: "20m", Source: "serial"},
+		Frame: api.FrameInfo{
+			Source:      "/dev/ttyUSB0",
+			Length:      371,
+			StartOffset: 9,
+			ScreenText:  text,
+			LCDFlags:    flags,
+		},
+		FrameKind: "serial",
+		Source:    "serial",
+		Sequence:  sequence,
+		UpdatedAt: time.Date(2026, 7, 20, 13, 59, int(sequence), 0, time.UTC),
+	}
+}
+
+func snapshotServer(t *testing.T, snapshots []ampRuntime.Snapshot) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	index := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/version":
+			_ = json.NewEncoder(w).Encode(api.Response{Success: true, Data: VersionInfo{Version: "1.2.3", Commit: "abc123"}})
+		case "/api/v1/runtime/snapshot":
+			mu.Lock()
+			if index >= len(snapshots) {
+				mu.Unlock()
+				t.Error("received more snapshot requests than expected")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			snapshot := snapshots[index]
+			index++
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(api.Response{Success: true, Data: snapshot})
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func readRecords(t *testing.T, path string) []Record {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	records := make([]Record, 0, len(lines))
+	for _, line := range lines {
+		var record Record
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decode record: %v", err)
+		}
+		records = append(records, record)
+	}
+	return records
+}

--- a/internal/server/display_text.go
+++ b/internal/server/display_text.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/FtlC-ian/expert-amp-server/internal/api"
+	"github.com/FtlC-ian/expert-amp-server/internal/display"
+	"github.com/FtlC-ian/expert-amp-server/internal/runtime"
+)
+
+func displayTextFromSnapshot(snapshot runtime.Snapshot, modelName string) api.DisplayText {
+	rows := make([]string, display.Rows)
+	spans := make([]api.DisplayTextSpan, 0)
+	selected := make([]string, 0)
+
+	for row := 0; row < display.Rows; row++ {
+		decoded := make([]rune, display.Cols)
+		for col := 0; col < display.Cols; col++ {
+			decoded[col] = decodeStateTextChar(snapshot.State.Chars[row][col], snapshot.State.Attrs[row][col])
+		}
+		rows[row] = string(decoded)
+
+		for start := 0; start < display.Cols; {
+			if !isHighlighted(snapshot.State.Attrs[row][start]) {
+				start++
+				continue
+			}
+			end := start + 1
+			for end < display.Cols && isHighlighted(snapshot.State.Attrs[row][end]) {
+				end++
+			}
+			text := string(decoded[start:end])
+			spans = append(spans, api.DisplayTextSpan{
+				Row:         row,
+				StartColumn: start,
+				EndColumn:   end,
+				Text:        text,
+			})
+			if trimmed := strings.TrimSpace(text); trimmed != "" {
+				selected = append(selected, trimmed)
+			}
+			start = end
+		}
+	}
+
+	return api.DisplayText{
+		Rows:             rows,
+		HighlightedSpans: spans,
+		SelectedText:     strings.Join(selected, "\n"),
+		Sequence:         snapshot.Sequence,
+		UpdatedAt:        snapshot.UpdatedAt,
+		Source:           snapshot.Source,
+		ModelName:        modelName,
+		ScreenText:       snapshot.Frame.ScreenText,
+	}
+}
+
+func decodeStateTextChar(value byte, attr byte) rune {
+	// Match the renderer's alternate-bank lookup before interpreting the
+	// effective ROM slot as text. Byte subtraction intentionally wraps just as
+	// font.ROM.Glyph does for malformed/unknown combinations.
+	if attr&0x80 != 0 {
+		value -= 0x20
+	}
+	// Normalized display state stores shifted printable text in 0x01-0x5e.
+	// Slot 0x5f is blank in the bundled ROM, not the DEL control character.
+	// ROM slots 0x60-0x7f render blank, while 0x80-0xdf are custom glyphs that
+	// intentionally remain semantically undecoded.
+	if value >= 0x01 && value <= 0x5e {
+		return rune(value + 0x20)
+	}
+	return ' '
+}
+
+func isHighlighted(attr byte) bool {
+	// Attribute bit 7 selects an alternate glyph bank; only low bits mean
+	// reverse-video/highlight in the decoded display state.
+	return attr&0x7f != 0
+}

--- a/internal/server/display_text_test.go
+++ b/internal/server/display_text_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/FtlC-ian/expert-amp-server/internal/api"
+	"github.com/FtlC-ian/expert-amp-server/internal/display"
+	"github.com/FtlC-ian/expert-amp-server/internal/runtime"
+)
+
+func TestDisplayTextFromSnapshotPreservesGeometryAndHighlights(t *testing.T) {
+	state := display.NewState()
+	state.SetRow(2, "FAN MODE NORMAL")
+	for col := 9; col < 15; col++ {
+		state.SetAttr(2, col, 0x01)
+	}
+	state.Chars[3][0] = 0x80  // custom glyph: no guessed textual meaning
+	state.Chars[3][1] = 0x61  // blank ROM slot: must not become ASCII text
+	state.Chars[3][2] = 0x5f  // blank boundary slot: must not become DEL
+	state.SetAttr(3, 0, 0x80) // alternate glyph bank, not a highlight
+	state.Chars[3][3] = 0x41  // alternate bank resolves to ROM 0x21 ('A')
+	state.SetAttr(3, 3, 0x80)
+	updatedAt := time.Date(2026, time.July, 20, 13, 45, 0, 0, time.UTC)
+
+	got := displayTextFromSnapshot(runtime.Snapshot{
+		State:     state,
+		Frame:     api.FrameInfo{ScreenText: "FAN MODE NORMAL"},
+		Source:    "serial:/dev/ttyUSB0",
+		Sequence:  42,
+		UpdatedAt: updatedAt,
+	}, "EXPERT 2K-FA")
+
+	if len(got.Rows) != display.Rows {
+		t.Fatalf("rows = %d, want %d", len(got.Rows), display.Rows)
+	}
+	for row, text := range got.Rows {
+		if len([]rune(text)) != display.Cols {
+			t.Fatalf("row %d columns = %d, want %d", row, len([]rune(text)), display.Cols)
+		}
+	}
+	if got.Rows[2] != "FAN MODE NORMAL"+strings.Repeat(" ", 25) {
+		t.Fatalf("row 2 = %q", got.Rows[2])
+	}
+	if got.Rows[3][:3] != "   " {
+		t.Fatalf("non-text ROM slots decoded as %q, want blanks", got.Rows[3][:3])
+	}
+	if got.Rows[3][3] != 'A' {
+		t.Fatalf("alternate-bank glyph decoded as %q, want A", got.Rows[3][3])
+	}
+	if len(got.HighlightedSpans) != 1 {
+		t.Fatalf("highlighted spans = %+v, want one", got.HighlightedSpans)
+	}
+	span := got.HighlightedSpans[0]
+	if span.Row != 2 || span.StartColumn != 9 || span.EndColumn != 15 || span.Text != "NORMAL" {
+		t.Fatalf("highlighted span = %+v", span)
+	}
+	if got.SelectedText != "NORMAL" || got.Sequence != 42 || got.UpdatedAt != updatedAt || got.Source != "serial:/dev/ttyUSB0" || got.ModelName != "EXPERT 2K-FA" || got.ScreenText != "FAN MODE NORMAL" {
+		t.Fatalf("unexpected context: %+v", got)
+	}
+}
+
+func TestDisplayTextEndpointReturnsRuntimeEnvelope(t *testing.T) {
+	state := display.NewState()
+	state.SetRow(0, "SET MENU")
+	for col := 0; col < 3; col++ {
+		state.SetAttr(0, col, 0x01)
+	}
+	updatedAt := time.Date(2026, time.July, 20, 14, 0, 0, 0, time.UTC)
+	store := runtime.NewStore(runtime.Snapshot{
+		State:     state,
+		Telemetry: api.Telemetry{ModelName: "EXPERT 2K-FA"},
+		Frame:     api.FrameInfo{ScreenText: "SET MENU"},
+		Source:    "fixture:set-menu",
+		Sequence:  7,
+		UpdatedAt: updatedAt,
+	})
+	handler := newTestHandler(store, runtime.FixtureCatalog{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/display/text", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Success bool            `json:"success"`
+		Data    api.DisplayText `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body.Success || len(body.Data.Rows) != 8 || body.Data.Sequence != 7 || body.Data.SelectedText != "SET" || body.Data.ModelName != "EXPERT 2K-FA" {
+		t.Fatalf("unexpected body: %+v", body)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type = %q, want application/json", got)
+	}
+}
+
+func TestDisplayTextEndpointRejectsOtherMethodsWithAPIEnvelope(t *testing.T) {
+	handler := newTestHandler(runtime.NewStore(runtime.Snapshot{}), runtime.FixtureCatalog{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/display/text", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+	var body api.Response
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Success || body.Error == "" {
+		t.Fatalf("unexpected body: %+v", body)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -199,6 +199,18 @@ func NewHandler(opts Options) http.Handler {
 		writeAPI(w, http.StatusOK, api.Response{Success: true, Data: resp})
 	})
 
+	mux.HandleFunc("/api/v1/display/text", func(w http.ResponseWriter, r *http.Request) {
+		if !allowMethodAPI(w, r, http.MethodGet) {
+			return
+		}
+		snapshot := currentSnapshot(opts.Store)
+		modelName := snapshot.Telemetry.ModelName
+		if opts.StatusState != nil {
+			modelName = opts.StatusState.Resolve(snapshot).ModelName
+		}
+		writeAPI(w, http.StatusOK, api.Response{Success: true, Data: displayTextFromSnapshot(snapshot, modelName)})
+	})
+
 	mux.HandleFunc("/api/v1/display/frame", func(w http.ResponseWriter, r *http.Request) {
 		if !allowMethodAPI(w, r, http.MethodGet) {
 			return


### PR DESCRIPTION
## Summary
- add `GET /api/v1/display/text` with fixed-width decoded rows, highlighted spans, selected text, sequence, model, and raw fallback
- add a GET-only passive recorder for unique display states and operator-labeled transitions
- retain exact character/attribute grids, LCD flags, metadata, and append-only evidence without screenshots or transcription
- document the accessible endpoint and hardware capture workflow

This is the first accessibility milestone discussed in #5. It does not yet implement model-specific menu recognition or automated traversal.

## Verification
- `go test ./...`
- `go test -race ./internal/capture ./internal/server`
- `go vet ./...`
- OpenAPI JSON validation
- live fixture endpoint and recorder smoke test
- independent review approved
- Codex review loop clean